### PR TITLE
fix for go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/tmcarey/steam-appticket-go
 
-go 1.30
+go 1.4
 
 require google.golang.org/protobuf v1.30.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/tmcarey/steam-appticket-go
 
-go 1.4
+go 1.22
 
-require google.golang.org/protobuf v1.30.0 // indirect
+require google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=


### PR DESCRIPTION
go version 1.30 doesn't exist, so this causes issues when depending on this package (for example when doing `go list -m -u all`

This will set it to a version that do exists.